### PR TITLE
Update Spiracle.properties

### DIFF
--- a/src/main/webapp/conf/Spiracle.properties
+++ b/src/main/webapp/conf/Spiracle.properties
@@ -5,7 +5,7 @@ c3p0.oracle.password=test
 c3p0.oracle.maxPoolSize=50
 
 c3p0.mysql.classname=com.mysql.jdbc.Driver
-c3p0.mysql.url=jdbc:mysql://localhost:3306/mysql
+c3p0.mysql.url=jdbc:mysql://localhost:3306/test
 c3p0.mysql.username=test
 c3p0.mysql.password=test
 c3p0.mysql.maxPoolSize=50


### PR DESCRIPTION
The database name in default configuration is `test` and not `mysql `so this little change fixes connection errors in default configuration.