### PR TITLE
Don't bundle mysql-5.1 Connector

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -110,8 +110,6 @@ c3p0.username=test
 c3p0.password=test
 ----
 
-NOTE: Spiracle is bundled with MySQL Connector 5.1.34. If this version is not compatible with your MySQL installation replace `mysql-connector-java-5.1.34.jar` under `WEB-INF/lib/` with a compatible version.
-
 == Running
 
 After deployment, the Spiracle application will be available at:

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,5 @@
             <artifactId>spring-expression</artifactId>
             <version>3.2.13.RELEASE</version>
         </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The bundled JDBC for Mysql 5.1 can stop the manually supplied JDBC from working for other versions of mysql