### PR TITLE
Use ServletContext.getRealPath() in xss/ReadHTML.java

### DIFF
--- a/src/main/java/com/waratek/spiracle/xss/ReadHTML.java
+++ b/src/main/java/com/waratek/spiracle/xss/ReadHTML.java
@@ -14,7 +14,7 @@ public class ReadHTML {
             throws IOException {
         String line = "";
         String XSS = "XSS";
-        String htmlFile = req.getRealPath("/") + "xss.html";
+        String htmlFile = req.getServletContext().getRealPath("/") + "xss.html";
 
         BufferedReader in = new BufferedReader(new FileReader(htmlFile));
         while ((line = in.readLine()) != null) {


### PR DESCRIPTION
WAL-4900. Use ServletContext.getRealPath() in xss/ReadHTML.java instead of deprecated ServletRequest.getRealPath()