### PR TITLE
policy(codeowners-w4j): apply remediations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @waratek/w4j


### PR DESCRIPTION
## Policy: codeowners-w4j

Every repository belonging to the Agents team must have a CODEOWNERS file

**Severity:** error

### Changes

- Create file CODEOWNERS *(rule: `ensure_file`)*
  - `CODEOWNERS` (create/update)

### Source

Policy defined in [waratek/cml @ cf9063f](https://github.com/waratek/cml/tree/cf9063f6cf0888ae5fc4d4889503c2053c584b52)
Opened by [workflow run (multipush apply)](https://github.com/waratek/cml/actions/runs/26819042019)

---
*Created by [multipush](https://github.com/JackuB/multipush) — declarative policy-as-code for GitHub repos.*
